### PR TITLE
Add utf-8 encoding for text file operations

### DIFF
--- a/src/auth/gmail_auth.py
+++ b/src/auth/gmail_auth.py
@@ -37,7 +37,7 @@ class GmailAuthenticator:
         creds_path = self._get_credentials_file_path()
         creds_path.parent.mkdir(exist_ok=True)
 
-        with open(creds_path, "w") as f:
+        with open(creds_path, "w", encoding="utf-8") as f:
             json.dump(creds_data, f, indent=2)
 
     def authenticate(self) -> bool:
@@ -60,7 +60,7 @@ class GmailAuthenticator:
                     self.creds = flow.run_local_server(port=0)
 
                 self.settings.credentials_path.parent.mkdir(exist_ok=True)
-                with open(self.settings.credentials_path, "w") as token:
+                with open(self.settings.credentials_path, "w", encoding="utf-8") as token:
                     token.write(self.creds.to_json())
 
             self.service = build("gmail", "v1", credentials=self.creds)

--- a/src/cli.py
+++ b/src/cli.py
@@ -75,7 +75,7 @@ OPENAI_MODEL=text-embedding-3-small
 CHROMA_PERSIST_DIRECTORY=data/chroma
 """
 
-    with open(env_path, "w") as f:
+    with open(env_path, "w", encoding="utf-8") as f:
         f.write(env_content)
 
     console.print("[green]✓ Configuration saved to .env file[/green]")

--- a/src/search/vector_store.py
+++ b/src/search/vector_store.py
@@ -60,7 +60,7 @@ class EmailVectorStore:
                 "collection_name": self.collection_name,
                 "model_id": self.model_id,
             }
-            with open(metadata_path, "w") as f:
+            with open(metadata_path, "w", encoding="utf-8") as f:
                 json.dump(sync_data, f)
         except Exception as e:
             console.print(f"[red]Error updating last sync date: {e}[/red]")
@@ -70,7 +70,7 @@ class EmailVectorStore:
         try:
             metadata_path = self._get_sync_metadata_path()
             if metadata_path.exists():
-                with open(metadata_path, "r") as f:
+                with open(metadata_path, "r", encoding="utf-8") as f:
                     sync_data = json.load(f)
                     last_sync_str = sync_data.get("last_sync_date")
                     if last_sync_str:
@@ -283,7 +283,7 @@ class EmailVectorStore:
             sync_file = metadata_dir / f"{c.name}_sync.json"
             if sync_file.exists():
                 try:
-                    with open(sync_file, "r") as f:
+                    with open(sync_file, "r", encoding="utf-8") as f:
                         sync_data = json.load(f)
                         metadata["last_sync_date"] = sync_data.get("last_sync_date")
                 except Exception:


### PR DESCRIPTION
## Summary
- ensure OAuth credentials, CLI env file and sync metadata use UTF-8

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669e4895bc83279d3be182bf526e9f